### PR TITLE
Goals page: CSV upload, manual entry, and goals table

### DIFF
--- a/src/app/goals/_components/GoalsPageClient.tsx
+++ b/src/app/goals/_components/GoalsPageClient.tsx
@@ -60,6 +60,7 @@ export function GoalsPageClient({ facilities }: GoalsPageClientProps) {
   const [csvRows, setCsvRows] = useState<CsvRow[]>([]);
   const [csvError, setCsvError] = useState<string | null>(null);
   const [csvFileName, setCsvFileName] = useState<string | null>(null);
+  const [skippedUpdates, setSkippedUpdates] = useState<Set<string>>(new Set());
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Manual form state
@@ -177,6 +178,7 @@ export function GoalsPageClient({ facilities }: GoalsPageClientProps) {
     }
     if (rows.length > 0) {
       setCsvRows(rows);
+      setSkippedUpdates(new Set()); // default all update rows to checked
     }
   }
 
@@ -189,15 +191,26 @@ export function GoalsPageClient({ facilities }: GoalsPageClientProps) {
     reader.readAsText(file);
   }
 
+  function toggleSkipped(sitelinkId: string) {
+    setSkippedUpdates((prev) => {
+      const next = new Set(prev);
+      if (next.has(sitelinkId)) next.delete(sitelinkId);
+      else next.add(sitelinkId);
+      return next;
+    });
+  }
+
   function handleCsvUpload() {
     const monthStr = `${selectedYear}-${String(selectedMonth).padStart(2, "0")}`;
-    const goals = csvRows.map((row) => ({
-      sitelinkId: row.sitelinkId,
-      month: monthStr,
-      rentalGoal: row.rentalGoal,
-      retailGoal: row.retailGoal,
-      collectionsGoal: row.collectionsGoal,
-    }));
+    const goals = csvRows
+      .filter((row) => !row.isUpdate || !skippedUpdates.has(row.sitelinkId))
+      .map((row) => ({
+        sitelinkId: row.sitelinkId,
+        month: monthStr,
+        rentalGoal: row.rentalGoal,
+        retailGoal: row.retailGoal,
+        collectionsGoal: row.collectionsGoal,
+      }));
 
     startTransition(async () => {
       const result = await upsertGoals(goals);
@@ -383,6 +396,7 @@ export function GoalsPageClient({ facilities }: GoalsPageClientProps) {
               <Table>
                 <TableHeader>
                   <TableRow>
+                    <TableHead className="w-8"></TableHead>
                     <TableHead>Facility</TableHead>
                     <TableHead className="text-right">Rental</TableHead>
                     <TableHead className="text-right">Retail ($)</TableHead>
@@ -391,36 +405,56 @@ export function GoalsPageClient({ facilities }: GoalsPageClientProps) {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {csvRows.map((row) => (
-                    <TableRow
-                      key={row.sitelinkId}
-                      className={row.isUpdate ? "bg-amber-50" : "bg-green-50"}
-                    >
-                      <TableCell>
-                        <span className="font-medium">{row.facilityAbbreviation}</span>{" "}
-                        <span className="text-muted-foreground text-sm">{row.facilityName}</span>
-                      </TableCell>
-                      <TableCell className="text-right">{row.rentalGoal}</TableCell>
-                      <TableCell className="text-right">${row.retailGoal.toLocaleString()}</TableCell>
-                      <TableCell className="text-right">${row.collectionsGoal.toLocaleString()}</TableCell>
-                      <TableCell>
-                        <Badge
-                          variant="outline"
-                          className={
-                            row.isUpdate
-                              ? "border-amber-500 text-amber-600"
-                              : "border-green-500 text-green-600"
-                          }
-                        >
-                          {row.isUpdate ? "Update" : "New"}
-                        </Badge>
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {csvRows.map((row) => {
+                    const checked = !skippedUpdates.has(row.sitelinkId);
+                    const dimmed = row.isUpdate && !checked;
+                    return (
+                      <TableRow
+                        key={row.sitelinkId}
+                        className={
+                          dimmed
+                            ? "bg-muted/40 opacity-50"
+                            : row.isUpdate
+                            ? "bg-amber-50"
+                            : "bg-green-50"
+                        }
+                      >
+                        <TableCell>
+                          {row.isUpdate && (
+                            <input
+                              type="checkbox"
+                              className="w-4 h-4"
+                              checked={checked}
+                              onChange={() => toggleSkipped(row.sitelinkId)}
+                            />
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <span className="font-medium">{row.facilityAbbreviation}</span>{" "}
+                          <span className="text-muted-foreground text-sm">{row.facilityName}</span>
+                        </TableCell>
+                        <TableCell className="text-right">{row.rentalGoal}</TableCell>
+                        <TableCell className="text-right">${row.retailGoal.toLocaleString()}</TableCell>
+                        <TableCell className="text-right">${row.collectionsGoal.toLocaleString()}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant="outline"
+                            className={
+                              row.isUpdate
+                                ? "border-amber-500 text-amber-600"
+                                : "border-green-500 text-green-600"
+                            }
+                          >
+                            {row.isUpdate ? "Update" : "New"}
+                          </Badge>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
                 </TableBody>
               </Table>
               <Button onClick={handleCsvUpload} disabled={isPending}>
-                {hasConflicts ? "Confirm Upload (overwrites existing)" : "Upload"}
+                {hasConflicts ? "Confirm Upload" : "Upload"}
               </Button>
             </div>
           )}

--- a/src/app/goals/_components/GoalsPageClient.tsx
+++ b/src/app/goals/_components/GoalsPageClient.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import { useState, useEffect, useTransition, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { getFacilitiesWithGoals, upsertGoals, FacilityGoalRow } from "../actions";
+
+type Facility = {
+  sitelinkId: string;
+  facilityAbbreviation: string;
+  facilityName: string;
+};
+
+type CsvRow = {
+  sitelinkId: string;
+  facilityAbbreviation: string;
+  facilityName: string;
+  rentalGoal: number;
+  retailGoal: number;
+  collectionsGoal: number;
+  isUpdate: boolean;
+};
+
+type GoalsPageClientProps = {
+  facilities: Facility[];
+};
+
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+const CURRENT_YEAR = new Date().getFullYear();
+const YEARS = [CURRENT_YEAR - 1, CURRENT_YEAR, CURRENT_YEAR + 1];
+
+export function GoalsPageClient({ facilities }: GoalsPageClientProps) {
+  const [selectedYear, setSelectedYear] = useState(CURRENT_YEAR);
+  const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth() + 1);
+  const [goalsData, setGoalsData] = useState<FacilityGoalRow[]>([]);
+  const [isPending, startTransition] = useTransition();
+
+  // CSV state
+  const [csvRows, setCsvRows] = useState<CsvRow[]>([]);
+  const [csvError, setCsvError] = useState<string | null>(null);
+  const [csvFileName, setCsvFileName] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Manual form state
+  const [manualFacility, setManualFacility] = useState(facilities[0]?.sitelinkId ?? "");
+  const [manualRental, setManualRental] = useState("");
+  const [manualRetail, setManualRetail] = useState("");
+  const [manualCollections, setManualCollections] = useState("");
+
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  function loadGoals(year: number, month: number) {
+    startTransition(async () => {
+      const data = await getFacilitiesWithGoals(year, month);
+      setGoalsData(data);
+    });
+  }
+
+  useEffect(() => {
+    loadGoals(selectedYear, selectedMonth);
+  }, [selectedYear, selectedMonth]);
+
+  // Build lookup maps from goalsData
+  const goalsByAbbrev = Object.fromEntries(
+    goalsData.map((r) => [r.facilityAbbreviation.toUpperCase(), r])
+  );
+  const goalsBySitelinkId = Object.fromEntries(
+    goalsData.map((r) => [r.sitelinkId, r])
+  );
+  const facilityByAbbrev = Object.fromEntries(
+    facilities.map((f) => [f.facilityAbbreviation.toUpperCase(), f])
+  );
+
+  function parseCsv(text: string) {
+    setCsvError(null);
+    setCsvRows([]);
+    const lines = text.trim().split(/\r?\n/);
+    if (lines.length < 2) {
+      setCsvError("File must have a header row and at least one data row.");
+      return;
+    }
+
+    const header = lines[0].split(",").map((h) => h.trim().toLowerCase());
+    const abbrevIdx = header.indexOf("abbreviation");
+    const sitelinkIdx = header.indexOf("sitelinkid");
+    const rentalIdx = header.indexOf("rentalgoal");
+    const retailIdx = header.indexOf("retailgoal");
+    const collectionsIdx = header.indexOf("collectionsgoal");
+
+    if (rentalIdx === -1 || retailIdx === -1 || collectionsIdx === -1) {
+      setCsvError(
+        "Missing required columns. Expected: rentalGoal, retailGoal, collectionsGoal"
+      );
+      return;
+    }
+    if (abbrevIdx === -1 && sitelinkIdx === -1) {
+      setCsvError(
+        "Missing facility identifier column. Expected: abbreviation or sitelinkId"
+      );
+      return;
+    }
+
+    const rows: CsvRow[] = [];
+    const errors: string[] = [];
+
+    for (let i = 1; i < lines.length; i++) {
+      const cols = lines[i].split(",").map((c) => c.trim());
+      if (cols.every((c) => c === "")) continue;
+
+      const rental = parseFloat(cols[rentalIdx]);
+      const retail = parseFloat(cols[retailIdx]);
+      const collections = parseFloat(cols[collectionsIdx]);
+
+      if (isNaN(rental) || isNaN(retail) || isNaN(collections)) {
+        errors.push(`Row ${i + 1}: invalid numeric values`);
+        continue;
+      }
+
+      let facility: Facility | undefined;
+      let existing: FacilityGoalRow | undefined;
+
+      if (abbrevIdx !== -1) {
+        const abbrev = cols[abbrevIdx].toUpperCase();
+        facility = facilityByAbbrev[abbrev];
+        existing = goalsByAbbrev[abbrev];
+      } else {
+        const sitelinkId = cols[sitelinkIdx];
+        facility = facilities.find((f) => f.sitelinkId === sitelinkId);
+        existing = goalsBySitelinkId[sitelinkId];
+      }
+
+      if (!facility) {
+        errors.push(
+          `Row ${i + 1}: facility not found for "${abbrevIdx !== -1 ? cols[abbrevIdx] : cols[sitelinkIdx]}"`
+        );
+        continue;
+      }
+
+      rows.push({
+        sitelinkId: facility.sitelinkId,
+        facilityAbbreviation: facility.facilityAbbreviation,
+        facilityName: facility.facilityName,
+        rentalGoal: rental,
+        retailGoal: retail,
+        collectionsGoal: collections,
+        isUpdate: existing != null && (
+          existing.rentalGoal != null ||
+          existing.retailGoal != null ||
+          existing.collectionsGoal != null
+        ),
+      });
+    }
+
+    if (errors.length > 0) {
+      setCsvError(errors.join("\n"));
+    }
+    if (rows.length > 0) {
+      setCsvRows(rows);
+    }
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setCsvFileName(file.name);
+    const reader = new FileReader();
+    reader.onload = (ev) => parseCsv(ev.target?.result as string);
+    reader.readAsText(file);
+  }
+
+  function handleCsvUpload() {
+    const monthStr = `${selectedYear}-${String(selectedMonth).padStart(2, "0")}`;
+    const goals = csvRows.map((row) => ({
+      sitelinkId: row.sitelinkId,
+      month: monthStr,
+      rentalGoal: row.rentalGoal,
+      retailGoal: row.retailGoal,
+      collectionsGoal: row.collectionsGoal,
+    }));
+
+    startTransition(async () => {
+      const result = await upsertGoals(goals);
+      setStatusMessage(
+        `Saved ${result.count} goal${result.count !== 1 ? "s" : ""} for ${MONTHS[selectedMonth - 1]} ${selectedYear}.`
+      );
+      setCsvRows([]);
+      setCsvFileName(null);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      loadGoals(selectedYear, selectedMonth);
+    });
+  }
+
+  function handleManualSubmit() {
+    const rental = parseFloat(manualRental);
+    const retail = parseFloat(manualRetail);
+    const collections = parseFloat(manualCollections);
+
+    if (isNaN(rental) || isNaN(retail) || isNaN(collections)) {
+      setStatusMessage("Please enter valid numbers for all goal fields.");
+      return;
+    }
+
+    const monthStr = `${selectedYear}-${String(selectedMonth).padStart(2, "0")}`;
+    startTransition(async () => {
+      await upsertGoals([
+        {
+          sitelinkId: manualFacility,
+          month: monthStr,
+          rentalGoal: rental,
+          retailGoal: retail,
+          collectionsGoal: collections,
+        },
+      ]);
+      setStatusMessage("Goal saved.");
+      setManualRental("");
+      setManualRetail("");
+      setManualCollections("");
+      loadGoals(selectedYear, selectedMonth);
+    });
+  }
+
+  const hasConflicts = csvRows.some((r) => r.isUpdate);
+
+  return (
+    <div className="space-y-6 p-6 max-w-5xl mx-auto">
+      <div className="flex items-center gap-4">
+        <h1 className="text-2xl font-bold">Monthly Goals</h1>
+        <div className="flex gap-2 ml-auto">
+          <Select
+            value={String(selectedMonth)}
+            onValueChange={(v) => setSelectedMonth(parseInt(v))}
+          >
+            <SelectTrigger className="w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MONTHS.map((name, i) => (
+                <SelectItem key={i + 1} value={String(i + 1)}>
+                  {name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={String(selectedYear)}
+            onValueChange={(v) => setSelectedYear(parseInt(v))}
+          >
+            <SelectTrigger className="w-24">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {YEARS.map((y) => (
+                <SelectItem key={y} value={String(y)}>
+                  {y}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Current goals table */}
+      <div>
+        <h2 className="text-lg font-semibold mb-2">
+          Current Goals — {MONTHS[selectedMonth - 1]} {selectedYear}
+        </h2>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Facility</TableHead>
+              <TableHead className="text-right">Rental</TableHead>
+              <TableHead className="text-right">Retail ($)</TableHead>
+              <TableHead className="text-right">Collections ($)</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isPending ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center text-muted-foreground">
+                  Loading…
+                </TableCell>
+              </TableRow>
+            ) : goalsData.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center text-muted-foreground">
+                  No facilities found.
+                </TableCell>
+              </TableRow>
+            ) : (
+              goalsData.map((row) => (
+                <TableRow key={row.sitelinkId}>
+                  <TableCell>
+                    <span className="font-medium">{row.facilityAbbreviation}</span>{" "}
+                    <span className="text-muted-foreground text-sm">{row.facilityName}</span>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {row.rentalGoal ?? <span className="text-muted-foreground">—</span>}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {row.retailGoal != null
+                      ? `$${row.retailGoal.toLocaleString()}`
+                      : <span className="text-muted-foreground">—</span>}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {row.collectionsGoal != null
+                      ? `$${row.collectionsGoal.toLocaleString()}`
+                      : <span className="text-muted-foreground">—</span>}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Input tabs */}
+      <Tabs defaultValue="csv">
+        <TabsList>
+          <TabsTrigger value="csv">Upload CSV</TabsTrigger>
+          <TabsTrigger value="manual">Manual Entry</TabsTrigger>
+        </TabsList>
+
+        {/* CSV tab */}
+        <TabsContent value="csv" className="space-y-4">
+          <div className="text-sm text-muted-foreground">
+            CSV format:{" "}
+            <code className="bg-muted px-1 rounded">
+              abbreviation,rentalGoal,retailGoal,collectionsGoal
+            </code>
+          </div>
+          <Input
+            type="file"
+            accept=".csv"
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            className="max-w-sm"
+          />
+          {csvError && (
+            <pre className="text-sm text-destructive whitespace-pre-wrap">{csvError}</pre>
+          )}
+
+          {csvRows.length > 0 && (
+            <div className="space-y-3">
+              {hasConflicts && (
+                <p className="text-sm text-amber-600 font-medium">
+                  Rows marked <Badge variant="outline" className="border-amber-500 text-amber-600">Update</Badge> will overwrite existing goals.
+                </p>
+              )}
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Facility</TableHead>
+                    <TableHead className="text-right">Rental</TableHead>
+                    <TableHead className="text-right">Retail ($)</TableHead>
+                    <TableHead className="text-right">Collections ($)</TableHead>
+                    <TableHead></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {csvRows.map((row) => (
+                    <TableRow
+                      key={row.sitelinkId}
+                      className={row.isUpdate ? "bg-amber-50" : "bg-green-50"}
+                    >
+                      <TableCell>
+                        <span className="font-medium">{row.facilityAbbreviation}</span>{" "}
+                        <span className="text-muted-foreground text-sm">{row.facilityName}</span>
+                      </TableCell>
+                      <TableCell className="text-right">{row.rentalGoal}</TableCell>
+                      <TableCell className="text-right">${row.retailGoal.toLocaleString()}</TableCell>
+                      <TableCell className="text-right">${row.collectionsGoal.toLocaleString()}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="outline"
+                          className={
+                            row.isUpdate
+                              ? "border-amber-500 text-amber-600"
+                              : "border-green-500 text-green-600"
+                          }
+                        >
+                          {row.isUpdate ? "Update" : "New"}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              <Button onClick={handleCsvUpload} disabled={isPending}>
+                {hasConflicts ? "Confirm Upload (overwrites existing)" : "Upload"}
+              </Button>
+            </div>
+          )}
+        </TabsContent>
+
+        {/* Manual entry tab */}
+        <TabsContent value="manual" className="space-y-4 max-w-sm">
+          <div className="space-y-3">
+            <div>
+              <label className="text-sm font-medium">Facility</label>
+              <Select value={manualFacility} onValueChange={setManualFacility}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {facilities.map((f) => (
+                    <SelectItem key={f.sitelinkId} value={f.sitelinkId}>
+                      {f.facilityAbbreviation} — {f.facilityName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Rental Goal</label>
+              <Input
+                type="number"
+                placeholder="e.g. 25"
+                value={manualRental}
+                onChange={(e) => setManualRental(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Retail Goal ($)</label>
+              <Input
+                type="number"
+                placeholder="e.g. 500"
+                value={manualRetail}
+                onChange={(e) => setManualRetail(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Collections Goal ($)</label>
+              <Input
+                type="number"
+                placeholder="e.g. 50000"
+                value={manualCollections}
+                onChange={(e) => setManualCollections(e.target.value)}
+              />
+            </div>
+            <Button onClick={handleManualSubmit} disabled={isPending}>
+              Save Goal
+            </Button>
+          </div>
+        </TabsContent>
+      </Tabs>
+
+      {statusMessage && (
+        <p className="text-sm text-green-600 font-medium">{statusMessage}</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/goals/_components/GoalsPageClient.tsx
+++ b/src/app/goals/_components/GoalsPageClient.tsx
@@ -349,13 +349,26 @@ export function GoalsPageClient({ facilities }: GoalsPageClientProps) {
               abbreviation,rentalGoal,retailGoal,collectionsGoal
             </code>
           </div>
-          <Input
-            type="file"
-            accept=".csv"
-            ref={fileInputRef}
-            onChange={handleFileChange}
-            className="max-w-sm"
-          />
+          <div className="flex items-center gap-3">
+            <input
+              type="file"
+              accept=".csv"
+              ref={fileInputRef}
+              onChange={handleFileChange}
+              className="hidden"
+              id="csv-file-input"
+            />
+            <Button
+              variant="outline"
+              onClick={() => fileInputRef.current?.click()}
+              type="button"
+            >
+              Choose CSV File
+            </Button>
+            {csvFileName && (
+              <span className="text-sm text-muted-foreground">{csvFileName}</span>
+            )}
+          </div>
           {csvError && (
             <pre className="text-sm text-destructive whitespace-pre-wrap">{csvError}</pre>
           )}

--- a/src/app/goals/actions.ts
+++ b/src/app/goals/actions.ts
@@ -1,0 +1,102 @@
+"use server";
+
+import { auth } from "@/auth";
+import { db } from "@/db";
+import monthlyGoals from "@/db/schema/monthlyGoals";
+import { storageFacilities } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+
+export type FacilityGoalRow = {
+  sitelinkId: string;
+  facilityAbbreviation: string;
+  facilityName: string;
+  rentalGoal: number | null;
+  retailGoal: number | null;
+  collectionsGoal: number | null;
+};
+
+export type UpsertGoalInput = {
+  sitelinkId: string;
+  month: string; // "YYYY-MM-01"
+  rentalGoal: number;
+  retailGoal: number;
+  collectionsGoal: number;
+};
+
+export async function getFacilitiesWithGoals(
+  year: number,
+  month: number
+): Promise<FacilityGoalRow[]> {
+  const session = await auth();
+  if (!session?.user) throw new Error("Unauthorized");
+
+  const firstOfMonth = new Date(year, month - 1, 1);
+
+  const facilities = await db.query.storageFacilities.findMany({
+    where: eq(storageFacilities.currentClient, true),
+    columns: {
+      sitelinkId: true,
+      facilityAbbreviation: true,
+      facilityName: true,
+    },
+    with: {
+      monthlyGoals: {
+        where: (mg, { eq }) => eq(mg.month, firstOfMonth),
+      },
+    },
+    orderBy: (sf, { asc }) => asc(sf.facilityAbbreviation),
+  });
+
+  return facilities.map((f) => ({
+    sitelinkId: f.sitelinkId,
+    facilityAbbreviation: f.facilityAbbreviation,
+    facilityName: f.facilityName,
+    rentalGoal: f.monthlyGoals[0]?.rentalGoal ?? null,
+    retailGoal:
+      f.monthlyGoals[0]?.retailGoal != null
+        ? parseFloat(f.monthlyGoals[0].retailGoal as unknown as string)
+        : null,
+    collectionsGoal:
+      f.monthlyGoals[0]?.collectionsGoal != null
+        ? parseFloat(f.monthlyGoals[0].collectionsGoal as unknown as string)
+        : null,
+  }));
+}
+
+export async function upsertGoals(
+  goals: UpsertGoalInput[]
+): Promise<{ count: number }> {
+  const session = await auth();
+  if (!session?.user) throw new Error("Unauthorized");
+
+  const values = goals.map((g) => {
+    const [yearStr, monthStr] = g.month.split("-");
+    const firstOfMonth = new Date(
+      parseInt(yearStr),
+      parseInt(monthStr) - 1,
+      1
+    );
+    return {
+      month: firstOfMonth,
+      sitelinkId: g.sitelinkId,
+      rentalGoal: g.rentalGoal,
+      retailGoal: String(g.retailGoal),
+      collectionsGoal: String(g.collectionsGoal),
+    };
+  });
+
+  await db
+    .insert(monthlyGoals)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [monthlyGoals.month, monthlyGoals.sitelinkId],
+      set: {
+        rentalGoal: sql`excluded.rental_goal`,
+        retailGoal: sql`excluded.retail_goal`,
+        collectionsGoal: sql`excluded.collections_goal`,
+      },
+    });
+
+  return { count: goals.length };
+}

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -1,31 +1,38 @@
 import { auth } from "@/auth";
-import { AddMonthlyGoalForm } from "@/components/AddMonthlyGoalForm";
-import { Table } from "@/components/ui/table";
-import { getFacilityConnections } from "@/lib/controllers/facilityController";
 import { Protected, ROLES } from "@/contexts/AuthContext";
-async function AddGoal() {
+import { db } from "@/db";
+import { storageFacilities } from "@/db/schema";
+import { eq, asc } from "drizzle-orm";
+import { GoalsPageClient } from "./_components/GoalsPageClient";
+
+async function GoalsPage() {
   const session = await auth();
-  if (!session?.user?.userDetailId) {
+  if (!session?.user) {
     return <div>Access denied. Please contact an administrator.</div>;
   }
-  const facilities = await getFacilityConnections(
-    session?.user?.userDetailId || ""
-  );
+
+  const facilities = await db.query.storageFacilities.findMany({
+    where: eq(storageFacilities.currentClient, true),
+    columns: {
+      sitelinkId: true,
+      facilityAbbreviation: true,
+      facilityName: true,
+    },
+    orderBy: asc(storageFacilities.facilityAbbreviation),
+  });
+
   return (
     <Protected
       roles={[ROLES.ADMIN, ROLES.SUPERVISOR, ROLES.MANAGER]}
       fallback={
         <div className="flex min-h-screen items-center justify-center">
-          {" "}
-          <p className="text-lg">
-            You do not have permission to view this page.
-          </p>{" "}
+          <p className="text-lg">You do not have permission to view this page.</p>
         </div>
       }
     >
-      {" "}
-      <AddMonthlyGoalForm facilities={facilities} />{" "}
+      <GoalsPageClient facilities={facilities} />
     </Protected>
   );
 }
-export default AddGoal;
+
+export default GoalsPage;

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -1,14 +1,21 @@
 import { auth } from "@/auth";
-import { Protected, ROLES } from "@/contexts/AuthContext";
 import { db } from "@/db";
 import { storageFacilities } from "@/db/schema";
 import { eq, asc } from "drizzle-orm";
 import { GoalsPageClient } from "./_components/GoalsPageClient";
 
+const ALLOWED_ROLES = ["ADMIN", "SUPERVISOR", "MANAGER", "OWNER"];
+
 async function GoalsPage() {
   const session = await auth();
-  if (!session?.user) {
-    return <div>Access denied. Please contact an administrator.</div>;
+  const role = session?.user?.role as string | null | undefined;
+
+  if (!session?.user || !role || !ALLOWED_ROLES.includes(role)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-lg">You do not have permission to view this page.</p>
+      </div>
+    );
   }
 
   const facilities = await db.query.storageFacilities.findMany({
@@ -21,18 +28,7 @@ async function GoalsPage() {
     orderBy: asc(storageFacilities.facilityAbbreviation),
   });
 
-  return (
-    <Protected
-      roles={[ROLES.ADMIN, ROLES.SUPERVISOR, ROLES.MANAGER]}
-      fallback={
-        <div className="flex min-h-screen items-center justify-center">
-          <p className="text-lg">You do not have permission to view this page.</p>
-        </div>
-      }
-    >
-      <GoalsPageClient facilities={facilities} />
-    </Protected>
-  );
+  return <GoalsPageClient facilities={facilities} />;
 }
 
 export default GoalsPage;


### PR DESCRIPTION
## Summary
- Replaces the old single-entry `/goals` form with a full goals management page
- Month picker (month + year dropdowns) controls which month is displayed and targeted for edits
- Current goals table shows all active facilities for the selected month with `—` for unset values
- **CSV upload tab** (default): parses `abbreviation,rentalGoal,retailGoal,collectionsGoal` format, previews rows with green (New) / amber (Update) badges, per-row checkboxes on Update rows (all checked by default) let you choose which records get overwritten before confirming
- **Manual entry tab**: facility dropdown + three goal fields, saves one facility at a time
- Auth check moved server-side to include OWNER role (previously only ADMIN/SUPERVISOR/MANAGER were allowed via client-side Protected component)
- Server actions in `goals/actions.ts` use `onConflictDoUpdate` for upserts

## Test plan
- [ ] Navigate to `/goals` — verify page loads and current goals table shows for the current month
- [ ] Change month/year — verify table refreshes
- [ ] Upload a CSV with new facilities — verify all rows show as green New, upload succeeds, table updates
- [ ] Upload a CSV with existing facilities — verify rows show as amber Update with checkboxes checked
- [ ] Uncheck one Update row and confirm — verify that row is skipped, others are saved
- [ ] Use Manual Entry tab to set a single facility goal — verify it saves and table refreshes
- [ ] Verify users with OWNER role can access the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)